### PR TITLE
La til DeepPartial type

### DIFF
--- a/components/form/ApplicationForm.tsx
+++ b/components/form/ApplicationForm.tsx
@@ -3,10 +3,10 @@ import RadioInput from "./RadioInput";
 import TextAreaInput from "./TextAreaInput";
 import SelectInput from "./SelectInput";
 import Line from "./Line";
-import { applicantType } from "../../lib/types/types";
+import { DeepPartial, applicantType } from "../../lib/types/types";
 
 interface Props {
-  applicationData: applicantType;
+  applicationData: DeepPartial<applicantType>;
   setApplicationData: Function;
 }
 
@@ -84,7 +84,7 @@ export const ApplicationForm = (props: Props) => {
       <Line />
 
       <div className="flex justify-center">
-        <label className="inline-block form-label text-gray-700 mt-6">
+        <label className="inline-block mt-6 text-gray-700 form-label">
           Velg opp til 3 komitéer
         </label>
       </div>

--- a/lib/types/types.ts
+++ b/lib/types/types.ts
@@ -1,3 +1,7 @@
+export type DeepPartial<T> = {
+  [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P];
+};
+
 export type commiteeType = {
   name: string;
   email: string;
@@ -21,13 +25,13 @@ export type applicantType = {
     second: string;
     third: string;
   };
-  bankom: "yes" | "no" | "maybe" | undefined;
-  feminIt: "yes" | "no" | undefined;
-  selectedTimes?: [
+  bankom: "yes" | "no" | "maybe";
+  feminIt: "yes" | "no";
+  selectedTimes: [
     {
       start: string;
       end: string;
     },
   ];
-  date?: Date;
+  date: Date;
 };

--- a/pages/form.tsx
+++ b/pages/form.tsx
@@ -11,7 +11,7 @@ import CheckIcon from "../components/icons/icons/CheckIcon";
 import Button from "../components/Button";
 import CalendarIcon from "../components/icons/icons/CalendarIcon";
 import { Tabs } from "../components/Tabs";
-import { applicantType } from "../lib/types/types";
+import { DeepPartial, applicantType } from "../lib/types/types";
 
 const Form: NextPage = () => {
   const { data: session } = useSession();
@@ -19,21 +19,14 @@ const Form: NextPage = () => {
   const [hasAlreadySubmitted, setHasAlreadySubmitted] = useState(false);
   const [activeTab, setActiveTab] = useState(0);
   const [isLoading, setIsLoading] = useState(true);
-  const [applicationData, setApplicationData] = useState<applicantType>({
-    owId: session?.user?.owId || "",
-    name: session?.user?.name || "",
-    email: session?.user?.email || "",
-    phone: session?.user?.phone || "",
-    grade: session?.user?.grade || 0,
-    about: "",
-    bankom: undefined,
-    feminIt: undefined,
-    preferences: {
-      first: "",
-      second: "",
-      third: "",
-    },
-    selectedTimes: undefined,
+  const [applicationData, setApplicationData] = useState<
+    DeepPartial<applicantType>
+  >({
+    owId: session?.user?.owId,
+    name: session?.user?.name,
+    email: session?.user?.email,
+    phone: session?.user?.phone,
+    grade: session?.user?.grade,
   });
 
   useEffect(() => {
@@ -151,7 +144,7 @@ const Form: NextPage = () => {
                       applicationData={applicationData}
                       setApplicationData={setApplicationData}
                     />
-                    <div className="flex w-full justify-center">
+                    <div className="flex justify-center w-full">
                       <Button
                         title="Videre"
                         color="blue"
@@ -211,7 +204,7 @@ const Form: NextPage = () => {
                       <br />
                       <br />
                     </div>
-                    <div className="flex w-full justify-center">
+                    <div className="flex justify-center w-full">
                       <Button
                         title="Send inn søknad"
                         color="blue"


### PR DESCRIPTION
Gjør det mulig for objekter av en type å ha udefinerte attributter, selv om selve typen ikke godkjenner det. Nice å bruke i feks. skjemaet hvor flere at atributtene er udefinert til å begynne med, frem til bruker fyller inn.